### PR TITLE
Repo-level locks

### DIFF
--- a/.devcontainer/docker-compose.yaml
+++ b/.devcontainer/docker-compose.yaml
@@ -42,6 +42,7 @@ services:
       - 'AZURE_STORAGE_ACCESS_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=='
       - 'AZURE_STORAGE_CUSTOM_ENDPOINT=azurite:10000'
       - 'AZURE_STORAGE_TLS=false'
+      - 'AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://azurite:10000/devstoreaccount1'
       - 'AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE'
       - 'AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
       - 'PRVT_STORE=local:/home/vscode/prvt-data'

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -10,3 +10,11 @@ gpg --list-secret-keys
 
 # Fix permissions
 sudo chown vscode:vscode /home/vscode/prvt-data
+
+# Create the "prvt" container in the Azure Storage emulator (Azurite)
+# Authentication is through the AZURE_STORAGE_CONNECTION_STRING environmental variable
+az storage container create --name prvt
+
+# Configure Minio client to access the minio container, then create the "prvt" bucket
+mc alias set minio http://$S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY
+mc mb minio/prvt

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -84,7 +84,7 @@ You must specify a destination, which is a folder inside the repository where yo
 			}
 
 			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			err = store.AcquireLock(ctx)
 			cancel()
 			if err != nil {

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -90,7 +90,7 @@ You must specify a destination, which is a folder inside the repository where yo
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -67,7 +67,7 @@ Shows the list of all files and folders contained in the repository at a given p
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -18,9 +18,11 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/fs/fsindex"
@@ -57,6 +59,15 @@ Shows the list of all files and folders contained in the repository at a given p
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -18,11 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/fs/fsindex"
@@ -55,19 +53,11 @@ Shows the list of all files and folders contained in the repository at a given p
 			}
 
 			// Create the store object
+			// No need for a lock for this command
 			store, err := fs.GetWithConnectionString(flagStoreConnectionString)
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
-
-			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err = store.AcquireLock(ctx)
-			cancel()
-			if err != nil {
-				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
-			}
-			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-info.go
+++ b/cmd/repo-info.go
@@ -18,7 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/fs/fsindex"
@@ -52,6 +54,15 @@ func NewRepoInfoCmd() *cobra.Command {
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-info.go
+++ b/cmd/repo-info.go
@@ -18,9 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/fs/fsindex"
@@ -50,19 +48,11 @@ func NewRepoInfoCmd() *cobra.Command {
 			}
 
 			// Create the store object
+			// No need for a lock for this command
 			store, err := fs.GetWithConnectionString(flagStoreConnectionString)
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
-
-			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err = store.AcquireLock(ctx)
-			cancel()
-			if err != nil {
-				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
-			}
-			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-info.go
+++ b/cmd/repo-info.go
@@ -62,7 +62,7 @@ func NewRepoInfoCmd() *cobra.Command {
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-init.go
+++ b/cmd/repo-init.go
@@ -67,7 +67,7 @@ In order to use GPG keys, you need to have GPG version 2 installed separately. Y
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Create the info file after generating a new master key
 			info, errMessage, err := NewInfoFile(flagGPGKey)

--- a/cmd/repo-init.go
+++ b/cmd/repo-init.go
@@ -18,8 +18,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 
@@ -57,6 +59,15 @@ In order to use GPG keys, you need to have GPG version 2 installed separately. Y
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize repository", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Create the info file after generating a new master key
 			info, errMessage, err := NewInfoFile(flagGPGKey)

--- a/cmd/repo-init.go
+++ b/cmd/repo-init.go
@@ -61,7 +61,7 @@ In order to use GPG keys, you need to have GPG version 2 installed separately. Y
 			}
 
 			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			err = store.AcquireLock(ctx)
 			cancel()
 			if err != nil {

--- a/cmd/repo-key-add.go
+++ b/cmd/repo-key-add.go
@@ -18,7 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 
@@ -54,6 +56,15 @@ In order to use GPG keys, you need to have GPG version 2 installed separately. Y
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-add.go
+++ b/cmd/repo-key-add.go
@@ -58,7 +58,7 @@ In order to use GPG keys, you need to have GPG version 2 installed separately. Y
 			}
 
 			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			err = store.AcquireLock(ctx)
 			cancel()
 			if err != nil {

--- a/cmd/repo-key-add.go
+++ b/cmd/repo-key-add.go
@@ -64,7 +64,7 @@ In order to use GPG keys, you need to have GPG version 2 installed separately. Y
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-ls.go
+++ b/cmd/repo-key-ls.go
@@ -18,9 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/keys"
@@ -47,19 +45,11 @@ Usage: "prvt repo key ls --store <string>"
 			}
 
 			// Create the store object
+			// No need for a lock for this command
 			store, err := fs.GetWithConnectionString(flagStoreConnectionString)
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
-
-			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err = store.AcquireLock(ctx)
-			cancel()
-			if err != nil {
-				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
-			}
-			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-ls.go
+++ b/cmd/repo-key-ls.go
@@ -18,7 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/keys"
@@ -49,6 +51,15 @@ Usage: "prvt repo key ls --store <string>"
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-ls.go
+++ b/cmd/repo-key-ls.go
@@ -59,7 +59,7 @@ Usage: "prvt repo key ls --store <string>"
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-rm.go
+++ b/cmd/repo-key-rm.go
@@ -61,7 +61,7 @@ To identify a passphrase or a GPG key among those authorized, you can use the "p
 			}
 
 			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			err = store.AcquireLock(ctx)
 			cancel()
 			if err != nil {

--- a/cmd/repo-key-rm.go
+++ b/cmd/repo-key-rm.go
@@ -67,7 +67,7 @@ To identify a passphrase or a GPG key among those authorized, you can use the "p
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-rm.go
+++ b/cmd/repo-key-rm.go
@@ -18,8 +18,10 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 
@@ -57,6 +59,15 @@ To identify a passphrase or a GPG key among those authorized, you can use the "p
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-test.go
+++ b/cmd/repo-key-test.go
@@ -60,7 +60,7 @@ This command is particularly useful to determine the ID of a key that you want t
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-test.go
+++ b/cmd/repo-key-test.go
@@ -18,7 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 
@@ -50,6 +52,15 @@ This command is particularly useful to determine the ID of a key that you want t
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-key-test.go
+++ b/cmd/repo-key-test.go
@@ -18,9 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 
@@ -48,19 +46,11 @@ This command is particularly useful to determine the ID of a key that you want t
 			}
 
 			// Create the store object
+			// No need for a lock for this command
 			store, err := fs.GetWithConnectionString(flagStoreConnectionString)
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
-
-			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-			err = store.AcquireLock(ctx)
-			cancel()
-			if err != nil {
-				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
-			}
-			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-upgrade.go
+++ b/cmd/repo-upgrade.go
@@ -51,7 +51,7 @@ Usage: "prvt repo upgrade --store <string>"
 			}
 
 			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			err = store.AcquireLock(ctx)
 			cancel()
 			if err != nil {

--- a/cmd/repo-upgrade.go
+++ b/cmd/repo-upgrade.go
@@ -18,7 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 
@@ -47,6 +49,15 @@ Usage: "prvt repo upgrade --store <string>"
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/repo-upgrade.go
+++ b/cmd/repo-upgrade.go
@@ -57,7 +57,7 @@ Usage: "prvt repo upgrade --store <string>"
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -20,6 +20,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/fs/fsindex"
@@ -59,6 +60,15 @@ To remove a file, specify its exact path. To remove a folder recursively, specif
 			if err != nil || store == nil {
 				return NewExecError(ErrorUser, "Could not initialize store", err)
 			}
+
+			// Acquire a lock
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			err = store.AcquireLock(ctx)
+			cancel()
+			if err != nil {
+				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+			}
+			defer store.ReleaseLock()
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -68,7 +68,7 @@ To remove a file, specify its exact path. To remove a folder recursively, specif
 			if err != nil {
 				return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 			}
-			defer store.ReleaseLock()
+			defer store.ReleaseLock(context.Background())
 
 			// Request the info file
 			info, err := store.GetInfoFile()

--- a/cmd/rm.go
+++ b/cmd/rm.go
@@ -62,7 +62,7 @@ To remove a file, specify its exact path. To remove a folder recursively, specif
 			}
 
 			// Acquire a lock
-			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 			err = store.AcquireLock(ctx)
 			cancel()
 			if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -18,7 +18,9 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package cmd
 
 import (
+	"context"
 	"errors"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs"
 	"github.com/ItalyPaleAle/prvt/fs/fsindex"
@@ -92,6 +94,15 @@ You can use the optional "--address" and "--port" flags to control what address 
 				if err != nil || store == nil {
 					return NewExecError(ErrorUser, "Could not initialize store", err)
 				}
+
+				// Acquire a lock
+				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				err = store.AcquireLock(ctx)
+				cancel()
+				if err != nil {
+					return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
+				}
+				defer store.ReleaseLock()
 
 				// Request the info file
 				info, err = store.GetInfoFile()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,9 +82,6 @@ You can use the optional "--address" and "--port" flags to control what address 
 				return NewExecError(ErrorApp, "Cannot get flag 'read-only'", err)
 			}
 
-			// Release all store locks at the end, in case there's any
-			defer store.ReleaseLock(context.Background())
-
 			// Check if we have a store flag
 			if !flagNoRepo {
 				// Ensure the connection string is set
@@ -99,6 +96,7 @@ You can use the optional "--address" and "--port" flags to control what address 
 				}
 
 				// Acquire a lock
+				// The Server object will remove locks at the end, if any
 				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				err = store.AcquireLock(ctx)
 				cancel()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -82,6 +82,9 @@ You can use the optional "--address" and "--port" flags to control what address 
 				return NewExecError(ErrorApp, "Cannot get flag 'read-only'", err)
 			}
 
+			// Release all store locks at the end, in case there's any
+			defer store.ReleaseLock(context.Background())
+
 			// Check if we have a store flag
 			if !flagNoRepo {
 				// Ensure the connection string is set
@@ -102,7 +105,6 @@ You can use the optional "--address" and "--port" flags to control what address 
 				if err != nil {
 					return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 				}
-				defer store.ReleaseLock(context.Background())
 
 				// Request the info file
 				info, err = store.GetInfoFile()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -102,7 +102,7 @@ You can use the optional "--address" and "--port" flags to control what address 
 				if err != nil {
 					return NewExecError(ErrorApp, "Could not acquire a lock. Please make sure that no other instance of prvt is running with the same repo.", err)
 				}
-				defer store.ReleaseLock()
+				defer store.ReleaseLock(context.Background())
 
 				// Request the info file
 				info, err = store.GetInfoFile()

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -96,7 +96,7 @@ You can use the optional "--address" and "--port" flags to control what address 
 				}
 
 				// Acquire a lock
-				ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+				ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 				err = store.AcquireLock(ctx)
 				cancel()
 				if err != nil {

--- a/fs/fs-azure-storage.go
+++ b/fs/fs-azure-storage.go
@@ -690,11 +690,6 @@ func (f *AzureStorage) ReleaseLock(ctx context.Context) (err error) {
 }
 
 func (f *AzureStorage) BreakLock(ctx context.Context) (err error) {
-	// Silently short-circuit
-	if f.lockLeaseId == "" {
-		return nil
-	}
-
 	// Adding a semaphore here to prevent multiple operations on a lock
 	f.mux.Lock()
 	defer f.mux.Unlock()

--- a/fs/fs-azure-storage.go
+++ b/fs/fs-azure-storage.go
@@ -601,6 +601,14 @@ func (f *AzureStorage) Delete(ctx context.Context, name string, tag interface{})
 	return
 }
 
+func (f *AzureStorage) AcquireLock(ctx context.Context) (err error) {
+	return nil
+}
+
+func (f *AzureStorage) ReleaseLock() (err error) {
+	return nil
+}
+
 // Internal function that returns the URL object for a blob
 func (f *AzureStorage) blobUrl(name string) (blockBlobURL azblob.BlockBlobURL, err error) {
 	if name == "" {

--- a/fs/fs-azure-storage_test.go
+++ b/fs/fs-azure-storage_test.go
@@ -45,13 +45,18 @@ func TestFsAzure(t *testing.T) {
 	// Generate a container name
 	container := "prvttest" + RandString(6)
 
-	// Init the object
+	// Create 2 store objects
 	store := &AzureStorage{}
+	store2 := &AzureStorage{}
 	opts := map[string]string{
 		"type":      "azure",
 		"container": container,
 	}
 	err = store.InitWithOptionsMap(opts, cache)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = store2.InitWithOptionsMap(opts, cache)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -72,15 +77,18 @@ func TestFsAzure(t *testing.T) {
 	// Run the tests
 	t.Run("common tests", func(t *testing.T) {
 		tester := &testFs{
-			t:     t,
-			store: store,
-			cache: cache,
+			t:      t,
+			store:  store,
+			store2: store2,
+			cache:  cache,
 		}
 		tester.Run()
 	})
 }
 
 func removeAzureContainer(t *testing.T, store *AzureStorage, containerUrl azblob.ContainerURL) {
+	t.Helper()
+
 	_, err := containerUrl.Delete(context.Background(), azblob.ContainerAccessConditions{})
 	if !assert.NoError(t, err) {
 		return

--- a/fs/fs-local.go
+++ b/fs/fs-local.go
@@ -544,11 +544,6 @@ func (f *Local) ReleaseLock(ctx context.Context) (err error) {
 }
 
 func (f *Local) BreakLock(ctx context.Context) (err error) {
-	// Silently short-circuit
-	if f.lock == nil || !f.lock.Locked() {
-		return nil
-	}
-
 	return errors.New("filesystem-based locks cannot be broken; please terminate the process that owns the lock instead")
 }
 

--- a/fs/fs-local_test.go
+++ b/fs/fs-local_test.go
@@ -35,7 +35,7 @@ func TestFsLocal(t *testing.T) {
 		return
 	}
 
-	// Init the object
+	// Init the store object
 	store := &Local{}
 	opts := map[string]string{
 		"type": "local",

--- a/fs/fs-s3.go
+++ b/fs/fs-s3.go
@@ -495,6 +495,14 @@ func (f *S3) Delete(ctx context.Context, name string, tag interface{}) (err erro
 	return
 }
 
+func (f *S3) AcquireLock(ctx context.Context) (err error) {
+	return nil
+}
+
+func (f *S3) ReleaseLock() (err error) {
+	return nil
+}
+
 // Internal function that returns the path to the file on storage
 func (f *S3) filePath(name string) (path string, err error) {
 	if name == "" {

--- a/fs/fs-s3.go
+++ b/fs/fs-s3.go
@@ -503,6 +503,10 @@ func (f *S3) ReleaseLock(ctx context.Context) (err error) {
 	return nil
 }
 
+func (f *S3) BreakLock(ctx context.Context) (err error) {
+	return nil
+}
+
 // Internal function that returns the path to the file on storage
 func (f *S3) filePath(name string) (path string, err error) {
 	if name == "" {

--- a/fs/fs-s3.go
+++ b/fs/fs-s3.go
@@ -499,7 +499,7 @@ func (f *S3) AcquireLock(ctx context.Context) (err error) {
 	return nil
 }
 
-func (f *S3) ReleaseLock() (err error) {
+func (f *S3) ReleaseLock(ctx context.Context) (err error) {
 	return nil
 }
 

--- a/fs/fs-s3_test.go
+++ b/fs/fs-s3_test.go
@@ -18,11 +18,15 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package fs
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/fs/fsutils"
+
 	minio "github.com/minio/minio-go/v7"
 	"github.com/stretchr/testify/assert"
 )
@@ -45,13 +49,18 @@ func TestFsS3(t *testing.T) {
 	bucket := "prvttest" + RandString(6)
 	region := os.Getenv("S3_REGION")
 
-	// Init the object
+	// Create 2 store objects
 	store := &S3{}
+	store2 := &S3{}
 	opts := map[string]string{
 		"type":   "s3",
 		"bucket": bucket,
 	}
 	err = store.InitWithOptionsMap(opts, cache)
+	if !assert.NoError(t, err) {
+		return
+	}
+	err = store2.InitWithOptionsMap(opts, cache)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -66,29 +75,159 @@ func TestFsS3(t *testing.T) {
 	t.Log("Created bucket", bucket)
 	defer removeS3Bucket(t, store, bucket)
 
+	// Test S3 locks
+	t.Run("test S3 locks", testS3Locks(store, bucket))
+
 	// Run the tests
 	t.Run("common tests", func(t *testing.T) {
 		tester := &testFs{
-			t:     t,
-			store: store,
-			cache: cache,
+			t:      t,
+			store:  store,
+			store2: store2,
+			cache:  cache,
 		}
 		tester.Run()
 	})
+
+	// At the end, there should be no locks left over
+	t.Run("check lock folder", s3LockFolderPostCheck(store, bucket))
+}
+
+// For S3, locks are managed in a different way, so we need to do some special tests
+func testS3Locks(store *S3, bucket string) func(t *testing.T) {
+	return func(t *testing.T) {
+		var (
+			ctx = context.Background()
+			err error
+		)
+
+		// Create 2 locks, waiting 4 seconds in-between
+		_, err = store.client.Client.PutObject(ctx, bucket, "_locks/1", bytes.NewBuffer([]byte{1}), 1, minio.PutObjectOptions{})
+		if !assert.NoError(t, err) {
+			return
+		}
+		// Wait 5 seconds
+		// (Sadly, we must wait and pause the test because Minio doesn't let us fake the LastModified times)
+		time.Sleep(5 * time.Second)
+		_, err = store.client.Client.PutObject(ctx, bucket, "_locks/2", bytes.NewBuffer([]byte{1}), 1, minio.PutObjectOptions{})
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		// Set the lock duration to 3 seconds then try unlocking - call should return with error
+		// Note: we need to bring down S3LockRenewal too
+		prevS3LockDuration := S3LockDuration
+		prevS3LockRenewal := S3LockRenewal
+		S3LockDuration = 3
+		S3LockRenewal = 2
+		err = store.AcquireLock(ctx)
+		if !assert.Error(t, err) {
+			t.FailNow()
+		}
+		assert.Empty(t, store.lockId)
+		assert.Empty(t, store.lockRefreshStop)
+
+		// Sleep for 4 seconds so all locks expire, then try unlocking again - should succeed (and delete all expired locks)
+		time.Sleep(4 * time.Second)
+		err = store.AcquireLock(ctx)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+
+		// Sleep for another 2 seconds to ensure older locks are removed and the refresher has started
+		time.Sleep(2 * time.Second)
+		assert.NotEmpty(t, store.lockId)
+		assert.NotEmpty(t, store.lockRefreshStop)
+
+		// Read the contents of the lock file
+		lockContents1 := getS3LockFileContent(t, store, bucket)
+		// Sleep for 2 seconds so the lock should be renewed (2 seconds before the expiration in 3 seconds)
+		time.Sleep(2 * time.Second)
+		// Read the contents of the lock again
+		lockContents2 := getS3LockFileContent(t, store, bucket)
+		// Contents should be different
+		assert.True(t, lockContents1 != lockContents2)
+
+		// Release the lock
+		err = store.ReleaseLock(ctx)
+		if !assert.NoError(t, err) {
+			t.FailNow()
+		}
+		assert.Empty(t, store.lockId)
+		assert.Empty(t, store.lockRefreshStop)
+
+		// Restore lock duration to the previous value
+		S3LockDuration = prevS3LockDuration
+		S3LockRenewal = prevS3LockRenewal
+	}
+}
+
+func getS3LockFileContent(t *testing.T, store *S3, bucket string) string {
+	t.Helper()
+
+	ctx := context.Background()
+
+	// List the locks (there should be only one)
+	listCh := store.client.Client.ListObjects(ctx, bucket, minio.ListObjectsOptions{
+		Prefix: "/_locks/",
+	})
+	lockName := ""
+	for e := range listCh {
+		// If there's already a name, means there was more than 1 file
+		// We need to have a single lock
+		assert.Empty(t, lockName, "found more than one lock file")
+		lockName = e.Key
+	}
+
+	// Read the contents of the lock file
+	r, _, _, err := store.client.GetObject(ctx, bucket, lockName, minio.GetObjectOptions{})
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	content, err := ioutil.ReadAll(r)
+	r.Close()
+	if !assert.NoError(t, err) {
+		t.FailNow()
+	}
+	if !assert.NotEmpty(t, content) {
+		t.FailNow()
+	}
+
+	// Return the contents
+	return string(content)
+}
+
+func s3LockFolderPostCheck(store *S3, bucket string) func(t *testing.T) {
+	return func(t *testing.T) {
+		time.Sleep(100 * time.Millisecond)
+
+		listCh := store.client.Client.ListObjects(context.Background(), bucket, minio.ListObjectsOptions{
+			Prefix: "/_locks/",
+		})
+		found := 0
+		for range listCh {
+			found++
+		}
+		assert.Zero(t, found, "found locks not correctly deleted")
+	}
 }
 
 func removeS3Bucket(t *testing.T, store *S3, bucket string) {
+	t.Helper()
+
+	ctx := context.Background()
+
 	// Delete all files first
-	objectsCh := store.client.Client.ListObjects(context.Background(), bucket, minio.ListObjectsOptions{
+	objectsCh := store.client.Client.ListObjects(ctx, bucket, minio.ListObjectsOptions{
 		Recursive: true,
 	})
-	deleteCh := store.client.Client.RemoveObjects(context.Background(), bucket, objectsCh, minio.RemoveObjectsOptions{})
+	deleteCh := store.client.Client.RemoveObjects(ctx, bucket, objectsCh, minio.RemoveObjectsOptions{})
 	for e := range deleteCh {
 		t.Log("Deleted object", e.ObjectName)
 	}
 
 	// Delete the bucket
-	err := store.client.RemoveBucket(context.Background(), bucket)
+	err := store.client.RemoveBucket(ctx, bucket)
 	if err != nil {
 		t.Errorf("error while removing the bucket %s: %s", bucket, err)
 		return

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -168,6 +168,12 @@ type Fs interface {
 	// Delete a file from the filesystem
 	// If you pass a tag, the implementation might use that to ensure that the file on the filesystem hasn't been changed since it was read (optional)
 	Delete(ctx context.Context, name string, tag interface{}) (err error)
+
+	// AcquireLock acquires an exclusive lock, to help making sure that no other process is using the same repository
+	AcquireLock(ctx context.Context) (err error)
+
+	// ReleaseLock releases the lock
+	ReleaseLock() (err error)
 }
 
 // Base class for filesystems, which contains the key and data path

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -174,6 +174,9 @@ type Fs interface {
 
 	// ReleaseLock releases the lock
 	ReleaseLock(ctx context.Context) (err error)
+
+	// BreakLock breaks the lock that another process might be holding
+	BreakLock(ctx context.Context) (err error)
 }
 
 // Base class for filesystems, which contains the key and data path

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -173,7 +173,7 @@ type Fs interface {
 	AcquireLock(ctx context.Context) (err error)
 
 	// ReleaseLock releases the lock
-	ReleaseLock() (err error)
+	ReleaseLock(ctx context.Context) (err error)
 }
 
 // Base class for filesystems, which contains the key and data path

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cubewise-code/go-mime v0.0.0-20200519001935-8c5762b177d8
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-gonic/gin v1.6.3
+	github.com/gofrs/flock v0.8.0
 	github.com/gofrs/uuid v3.3.0+incompatible
 	github.com/golang/protobuf v1.4.3
 	github.com/google/tink/go v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
 github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
+github.com/gofrs/flock v0.8.0 h1:MSdYClljsF3PbENUUEx85nkWfJSGfzYI9yEBZOJz6CY=
+github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.3.0+incompatible h1:8K4tyRfvU1CYPgJsveYFQMhpFd/wXNM7iK6rR7UHz84=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -219,6 +221,7 @@ github.com/hashicorp/vault/sdk v0.1.13/go.mod h1:B+hVj7TpuQY1Y/GPbCpffmgd+tSEwvh
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
@@ -250,6 +253,7 @@ github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgx
 github.com/lunixbochs/vtclean v0.0.0-20180621232353-2d01aacdc34a/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
 github.com/lunixbochs/vtclean v1.0.0 h1:xu2sLAri4lGiovBDQKxl5mrXyESr3gUr5m5SM5+LVb8=
 github.com/lunixbochs/vtclean v1.0.0/go.mod h1:pHhQNgMf3btfWnGBVipUOjRYhoOsdGqdm/+2c2E2WMI=
+github.com/mackerelio/go-osstat v0.1.0 h1:e57QHeHob8kKJ5FhcXGdzx5O6Ktuc5RHMDIkeqhgkFA=
 github.com/mackerelio/go-osstat v0.1.0/go.mod h1:1K3NeYLhMHPvzUu+ePYXtoB58wkaRpxZsGClZBJyIFw=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=

--- a/index/index_test.go
+++ b/index/index_test.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	pb "github.com/ItalyPaleAle/prvt/index/proto"
+	"github.com/ItalyPaleAle/prvt/utils"
 
 	"github.com/gofrs/uuid"
 	"github.com/stretchr/testify/assert"
@@ -287,7 +288,7 @@ func listFiles(t *testing.T, path string) {
 			if pos > 0 {
 				e = e[:pos]
 			}
-			if !StringInSlice(exp, e) {
+			if !utils.StringInSlice(exp, e) {
 				exp = append(exp, e)
 			}
 		}
@@ -594,16 +595,4 @@ func (n *IndexTreeNode) dump(indent int) {
 			c.dump(indent + 1)
 		}
 	}
-}
-
-/* Utils */
-
-// StringInSlice checks if a string is contained inside a slice of strings
-func StringInSlice(list []string, a string) bool {
-	for _, b := range list {
-		if b == a {
-			return true
-		}
-	}
-	return false
 }

--- a/server/api-post-repo-close.go
+++ b/server/api-post-repo-close.go
@@ -18,7 +18,6 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package server
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 
@@ -28,8 +27,8 @@ import (
 // PostRepoCloseHandler is the handler for POST /api/repo/close, which closes any open repository
 func (s *Server) PostRepoCloseHandler(c *gin.Context) {
 	// If there's an existing store object, release locks (if any)
-	if s.Store != nil {
-		err := s.Store.ReleaseLock(context.Background())
+	err := s.releaseRepoLock()
+	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}

--- a/server/api-post-repo-close.go
+++ b/server/api-post-repo-close.go
@@ -18,6 +18,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
 package server
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -28,7 +29,7 @@ import (
 func (s *Server) PostRepoCloseHandler(c *gin.Context) {
 	// If there's an existing store object, release locks (if any)
 	if s.Store != nil {
-		err := s.Store.ReleaseLock()
+		err := s.Store.ReleaseLock(context.Background())
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}

--- a/server/api-post-repo-close.go
+++ b/server/api-post-repo-close.go
@@ -26,6 +26,13 @@ import (
 
 // PostRepoCloseHandler is the handler for POST /api/repo/close, which closes any open repository
 func (s *Server) PostRepoCloseHandler(c *gin.Context) {
+	// If there's an existing store object, release locks (if any)
+	if s.Store != nil {
+		err := s.Store.ReleaseLock()
+		c.AbortWithError(http.StatusInternalServerError, err)
+		return
+	}
+
 	// Reset the store, infofile, and repo variables
 	s.Store = nil
 	s.Infofile = nil

--- a/server/api-post-repo-select.go
+++ b/server/api-post-repo-select.go
@@ -75,8 +75,8 @@ func (s *Server) PostRepoSelectHandler(c *gin.Context) {
 	}
 
 	// If there's an existing store object, release locks (if any)
-	if s.Store != nil {
-		err = s.Store.ReleaseLock(context.Background())
+	err = s.releaseRepoLock()
+	if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}

--- a/server/api-post-repo-select.go
+++ b/server/api-post-repo-select.go
@@ -82,7 +82,7 @@ func (s *Server) PostRepoSelectHandler(c *gin.Context) {
 	}
 
 	// Acquire a lock
-	ctx, cancel := context.WithTimeout(c.Request.Context(), 3*time.Second)
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
 	err = store.AcquireLock(ctx)
 	cancel()
 	if err != nil {

--- a/server/api-post-repo-select.go
+++ b/server/api-post-repo-select.go
@@ -76,7 +76,7 @@ func (s *Server) PostRepoSelectHandler(c *gin.Context) {
 
 	// If there's an existing store object, release locks (if any)
 	if s.Store != nil {
-		err = s.Store.ReleaseLock()
+		err = s.Store.ReleaseLock(context.Background())
 		c.AbortWithError(http.StatusInternalServerError, err)
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -234,7 +234,7 @@ func (s *Server) launchServer(ctx context.Context, address, port string, router 
 		}
 
 		// We received an interrupt signal, shut down
-		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 3*time.Second)
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			// Error from closing listeners, or context timeout:
 			fmt.Fprintf(s.LogWriter, "HTTP server shutdown error: %v\n", err)

--- a/server/server.go
+++ b/server/server.go
@@ -250,5 +250,16 @@ func (s *Server) launchServer(ctx context.Context, address, port string, router 
 	}
 	<-idleConnsClosed
 
+	// Release all locks, if any
+	_ = s.releaseRepoLock()
+
 	return nil
+}
+
+func (s *Server) releaseRepoLock() (err error) {
+	// If there's an existing store object, release locks (if any)
+	if s.Store != nil {
+		err = s.Store.ReleaseLock(context.Background())
+	}
+	return
 }

--- a/tests/functional-previous-versions_test.go
+++ b/tests/functional-previous-versions_test.go
@@ -25,6 +25,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ItalyPaleAle/prvt/infofile"
 
@@ -71,6 +72,9 @@ func (s *funcTestSuite) RunPreviousVersions(t *testing.T) {
 	t.Run("prvt 0.5-gpg", func(t *testing.T) {
 		s.previousVersion_0_5(t, true)
 	})
+
+	// Sleep for 10 seconds to see if all locks are removd
+	time.Sleep(10 * time.Second)
 }
 
 // Tests for working with repositories created by version 0.2

--- a/utils/functions.go
+++ b/utils/functions.go
@@ -105,3 +105,13 @@ func SanitizeConnectionName(conn string) string {
 
 	return conn
 }
+
+// StringInSlice checks if a string is contained inside a slice of strings
+func StringInSlice(list []string, a string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
This PR implements repo-level locks, to make sure that no more than 1 instance of prvt can access the same repo at the same time.